### PR TITLE
Feature to use a filename in the ignored_issues file.

### DIFF
--- a/analyze_results.py
+++ b/analyze_results.py
@@ -189,8 +189,7 @@ class IgnoredIssues:
         self.issues_for_resource = {}
         self.element_ids         = []
         self.issues              = []
-
-        #toMatch = resource_id if resource_id is not None else file_path
+        
         if self.ignored_issues:
             for resource_regex in self.ignored_issues:
                 matchResult = False

--- a/analyze_results.py
+++ b/analyze_results.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import json, os, re, sys, yaml
-from nis import match
 import xml.etree.ElementTree as ET
 import xml.parsers.expat
 from optparse import OptionParser, OptionValueError


### PR DESCRIPTION
As not all our FHIR resources have an id we extended the script to use filename in the ignored_issues YAML file. 

With this extension the compare of the [resource.id] in the ignored issues is done on the FHIR id OR the Filename found in the validator output. If one of these matches is true the issue is ignored.