### PR TITLE
Add support for brackets

### DIFF
--- a/analyze_results.py
+++ b/analyze_results.py
@@ -255,7 +255,7 @@ class IgnoredIssues:
         return result
     
     def _wildcardToRegex(self, wildcard_string):
-        return re.compile("^" + wildcard_string.replace(".", "\.").replace("*", ".*?").replace("[", "\[").replace("]", "\]") + "$", re.MULTILINE)
+        return re.compile("^" + wildcard_string.replace(".", "\.").replace("*", ".*?").replace("[", "\[").replace("]", "\]").replace("(", "\(").replace(")", "\)") + "$", re.MULTILINE)
 
 class ResourceIssues:
     """ Container for all the issues for a single FHIR resource. """


### PR DESCRIPTION
Some of the locations that we use in the script have brackets e.g.
`Bundle.entry[*].resource.ofType(Group).code`

Currently the regex.match does not find a match. This is because the brackets `(` and `)` need to be escaped with a `\`

After this fix matching locations with brackets works as expected.