### PR TITLE
Deal with resources xml/json which are not parsable.

### DIFF
--- a/analyze_results.py
+++ b/analyze_results.py
@@ -277,15 +277,18 @@ class ResourceIssues:
         # Get the id of the resource, if any
         self.id = None
         if file_type == "xml":
-            resource_tree = ET.parse(file_path)
             try:
+                resource_tree = ET.parse(file_path)
                 self.id = resource_tree.find(".//f:id", ns).attrib["value"]
-            except AttributeError:
-                self.id = None
+            except:
+                pass    # In case of not parseable the error is already in the validation output file
         elif file_type == "json":
-            resource_tree = json.load(open(file_path))
-            if "id" in resource_tree:
-                self.id = resource_tree["id"]
+            try:
+                resource_tree = json.load(open(file_path))
+                if "id" in resource_tree:
+                    self.id = resource_tree["id"]
+            except:
+                pass    # In case of not parseable the error is already in the validation output file
 
         self.issues = []
         self.ignored_issues = ignored_issues

--- a/analyze_results.py
+++ b/analyze_results.py
@@ -276,19 +276,16 @@ class ResourceIssues:
 
         # Get the id of the resource, if any
         self.id = None
-        if file_type == "xml":
-            try:
+        try:
+            if file_type == "xml":
                 resource_tree = ET.parse(file_path)
                 self.id = resource_tree.find(".//f:id", ns).attrib["value"]
-            except:
-                pass    # In case of not parseable the error is already in the validation output file
-        elif file_type == "json":
-            try:
+            elif file_type == "json":
                 resource_tree = json.load(open(file_path))
                 if "id" in resource_tree:
                     self.id = resource_tree["id"]
-            except:
-                pass    # In case of not parseable the error is already in the validation output file
+        except:
+            pass    # In case of file not parseable, the error will be in the validation output file
 
         self.issues = []
         self.ignored_issues = ignored_issues

--- a/analyze_results.py
+++ b/analyze_results.py
@@ -285,7 +285,7 @@ class ResourceIssues:
                 if "id" in resource_tree:
                     self.id = resource_tree["id"]
         except:
-            pass    # In case of file not parseable, the error will be in the validation output file
+            self.id = None
 
         self.issues = []
         self.ignored_issues = ignored_issues


### PR DESCRIPTION
We noticed/learned that in case of an un-parsable resources, the python-script crashes.
Added a try-except structure around this part.
The hl7-validator reports the problem with the un-parsable resource nicely in the output.xml file, which the python-script nicely summarizes.

Anyway, thanks for the nice script.